### PR TITLE
Adding namespace option to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,9 @@
   // hide animation duration
   hideDuration: 200,
   // padding between element and notification
-  gap: 2
+  gap: 2,
+  // if specified, the namespace option will add a custom class to the notification wrapper
+  namespace: 'custom-class-name'
 }</pre>
       </div>
       <div class="sixteen columns">


### PR DESCRIPTION
Adds the documentation for the namespace option suggested in: https://github.com/notifyjs/notifyjs/pull/69
