### PR TITLE
Corrected misinformation

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         <h4>Global Notifications</h4>
         <p>
           If you don't specify an element, notification
-          will appear in the top left (unless you specify a
+          will appear in the top right (unless you specify a
           different position - See <a data-highlight>Positioning</a>)
         </p>
         <p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17814535/62836102-712b8480-bc25-11e9-9552-1ce2e333acba.png)

As you can see, clicking the text created a notification in the top right, not the top left.